### PR TITLE
update pdf-reader and include require dependency

### DIFF
--- a/lib/prawn/templates.rb
+++ b/lib/prawn/templates.rb
@@ -1,4 +1,5 @@
 # This is free software. See LICENSE and COPYING files for details.
+require 'pdf/reader'
 
 module Prawn
   # @private

--- a/prawn-templates.gemspec
+++ b/prawn-templates.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.authors = ["Gregory Brown","Brad Ediger","Daniel Nelson","Jonathan Greenberg","James Healy"]
   spec.email = ["gregory.t.brown@gmail.com","brad@bradediger.com","dnelson@bluejade.com","greenberg@entryway.net","jimmy@deefa.com"]
-  spec.add_dependency('pdf-reader', '~>1.2')
+  spec.add_dependency('pdf-reader', '~>1.3')
   spec.add_dependency('prawn', '>= 0.15.0')
   spec.add_development_dependency('pdf-inspector', '~> 1.1.0')
   spec.add_development_dependency('rspec')


### PR DESCRIPTION
will prevent an uninitialized constant PDF::Reader Exception
