### PR TITLE
Add Rubocop to CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,48 +8,9 @@ AsciiComments:
 IfUnlessModifier:
   Enabled: false
 
-# In this case we supress Prawn::Errors::CannotFit while trying to scale
-# text down to fit.
-HandleExceptions:
-  Exclude:
-    - lib/prawn/text/formatted/box.rb
-
 # %w() style arrays don't always look better.
 WordArray:
   Enabled: false
-
-# Due to some layout constraints in our examples we want to allow these rule to
-# be ignored in the manual.
-Style/ClosingParenthesisIndentation:
-  Exclude:
-    - manual/**/*
-LineEndConcatenation:
-  Exclude:
-    - manual/**/*
-MultilineOperationIndentation:
-  Exclude:
-    - manual/**/*
-    - prawn.gemspec
-Style/SpaceInsideParens:
-  Exclude:
-    - manual/**/*
-SingleSpaceBeforeFirstArg:
-  Exclude:
-    - manual/**/*
-
-# This file shows examples on how to instantiate a document in multiple ways,
-# it does not actually do the instantiation and isn't actually shadowing any
-# variables.
-ShadowingOuterLocalVariable:
-  Exclude:
-    - manual/basic_concepts/creation.rb
-
-# We currently ignore usage of semicolons on this page of the manual so we
-# don't have to worry about changing the content of the manual for now.
-Semicolon:
-  Exclude:
-    - manual/bounding_box/nesting.rb
-
 
 # This cops are candidates for enabling and doing the related cleanup and/or
 # refactoring

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,168 @@
+# We need to reference non-ascii characters when testing and explaining
+# behavior related to win-1252, UTF-8 and UTF-16 encodings for example.
+AsciiComments:
+  Enabled: false
+
+# We don't always prefer modified if statements even if they do fit on
+# a line.
+IfUnlessModifier:
+  Enabled: false
+
+# In this case we supress Prawn::Errors::CannotFit while trying to scale
+# text down to fit.
+HandleExceptions:
+  Exclude:
+    - lib/prawn/text/formatted/box.rb
+
+# %w() style arrays don't always look better.
+WordArray:
+  Enabled: false
+
+# Due to some layout constraints in our examples we want to allow these rule to
+# be ignored in the manual.
+Style/ClosingParenthesisIndentation:
+  Exclude:
+    - manual/**/*
+LineEndConcatenation:
+  Exclude:
+    - manual/**/*
+MultilineOperationIndentation:
+  Exclude:
+    - manual/**/*
+    - prawn.gemspec
+Style/SpaceInsideParens:
+  Exclude:
+    - manual/**/*
+SingleSpaceBeforeFirstArg:
+  Exclude:
+    - manual/**/*
+
+# This file shows examples on how to instantiate a document in multiple ways,
+# it does not actually do the instantiation and isn't actually shadowing any
+# variables.
+ShadowingOuterLocalVariable:
+  Exclude:
+    - manual/basic_concepts/creation.rb
+
+# We currently ignore usage of semicolons on this page of the manual so we
+# don't have to worry about changing the content of the manual for now.
+Semicolon:
+  Exclude:
+    - manual/bounding_box/nesting.rb
+
+
+# This cops are candidates for enabling and doing the related cleanup and/or
+# refactoring
+Style/BlockDelimiters:
+  Enabled: false
+  EnforcedStyle: semantic
+Void:
+  Enabled: false
+StringLiterals:
+  Enabled: false
+HashSyntax:
+  Enabled: false
+UselessAssignment:
+  Enabled: false
+Lambda:
+  Enabled: false
+LineLength:
+  Enabled: false
+SpaceBeforeBlockBraces:
+  Enabled: false
+SpaceInsideBrackets:
+  Enabled: false
+FormatString:
+  Enabled: false
+CollectionMethods:
+  Enabled: false
+DotPosition:
+  Enabled: false
+SingleLineBlockParams:
+  Enabled: false
+PercentLiteralDelimiters:
+  Enabled: false
+Documentation:
+  Enabled: false
+RegexpLiteral:
+  Enabled: false
+MethodLength:
+  Enabled: false
+VariableInterpolation:
+  Enabled: false
+AndOr:
+  Enabled: false
+AssignmentInCondition:
+  Enabled: false
+ClassAndModuleChildren:
+  Enabled: false
+NumericLiterals:
+  Enabled: false
+DoubleNegation:
+  Enabled: false
+SelfAssignment:
+  Enabled: false
+ClassLength:
+  Enabled: false
+CaseEquality:
+  Enabled: false
+RedundantSelf:
+  Enabled: false
+BlockNesting:
+  Enabled: false
+NegatedWhile:
+  Enabled: false
+MultilineIfThen:
+  Enabled: false
+ModuleFunction:
+  Enabled: false
+CyclomaticComplexity:
+  Enabled: false
+UnreachableCode:
+  Enabled: false
+AccessorMethodName:
+  Enabled: false
+SpaceAfterControlKeyword:
+  Enabled: false
+PredicateName:
+  Enabled: false
+ConstantName:
+  Enabled: false
+MethodName:
+  Enabled: false
+Alias:
+  Enabled: false
+RedundantReturn:
+  Enabled: false
+WhileUntilModifier:
+  Enabled: false
+StringConversionInInterpolation:
+  Enabled: false
+RedundantBegin:
+  Enabled: false
+PerlBackrefs:
+  Enabled: false
+ClassVars:
+  Enabled: false
+ParameterLists:
+  Enabled: false
+AbcSize:
+  Enabled: false
+PerceivedComplexity:
+  Enabled: false
+UnusedBlockArgument:
+  Enabled: false
+UnusedMethodArgument:
+  Enabled: false
+Next:
+  Enabled: false
+ClassCheck:
+  Enabled: false
+SpaceBeforeComma:
+  Enabled: false
+StringLiteralsInInterpolation:
+  Enabled: false
+GuardClause:
+  Enabled: false
+BlockEndNewline:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -3,9 +3,11 @@ Bundler.setup
 
 require 'rake'
 require 'rspec/core/rake_task'
-task :default => [:spec]
+task :default => [:spec, :rubocop]
 
 desc "Run all rspec files"
 RSpec::Core::RakeTask.new("spec") do |c|
   c.rspec_opts = "-t ~unresolved"
 end
+
+RuboCop::RakeTask.new

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@ Bundler.setup
 
 require 'rake'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+
 task :default => [:spec, :rubocop]
 
 desc "Run all rspec files"

--- a/prawn-templates.gemspec
+++ b/prawn-templates.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pdf-inspector', '~> 1.1.0')
   spec.add_development_dependency('rspec')
   spec.add_development_dependency('rake')
+  spec.add_development_dependency('rubocop', '0.30.1')
   spec.homepage = "http://prawn.majesticseacreature.com"
   spec.description = "Prawn::Templates allows using PDFs as templates in Prawn"
 end


### PR DESCRIPTION
This PR adds rubocop styles enforcing all the same rules that are currently enforced for the main Prawn codebase.

Note that the build is currently failing pending a successful merge of #3 

@bvogel Normally I would go ahead and correct all the style violations before merging this PR but I want to be mindful of causing you any merge conflicts when we start to try and get that PR merged. What are your thoughts?