### PR TITLE
Wrap existing page contents with q/Q to ensure graphics state is reset

### DIFF
--- a/lib/prawn/document/internals.rb
+++ b/lib/prawn/document/internals.rb
@@ -3,12 +3,18 @@ module Prawn
     module Internals
       delegate [:open_graphics_state] => :renderer
 
+      # wraps existing content streams with two new streams
+      # containing just 'q' and 'Q'. This ensures that prawn
+      # has a pristine graphics context before it starts adding content.
+      #
       # adds a new, empty content stream to each page. Used in templating so
       # that imported content streams can be left pristine
       #
       def fresh_content_streams(options = {})
         (1..page_count).each do |i|
           go_to_page i
+
+          state.page.wrap_graphics_state
           state.page.new_content_stream
           apply_margin_options(options)
           generate_margin_box

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 puts "PDF::Core specs: Running on Ruby Version: #{RUBY_VERSION}"
 
 require 'bundler'


### PR DESCRIPTION
This fixes the issue where a content stream contains a matrix transformation, which causes all of the Prawn content to also be transformed. By wrapping all of the existing content with calls to `q` and `Q`, we ensure that Prawn starts with a brand new graphics state.

See: https://github.com/prawnpdf/prawn-templates/issues/19

I've tested this manually, but need some advice for proper specs.