### PR TITLE
Fix case where prawn-templates would cause PDF contents to disappear

### DIFF
--- a/lib/pdf/core/page.rb
+++ b/lib/pdf/core/page.rb
@@ -22,6 +22,17 @@ module PDF
         end
       end
 
+      # If :Contents is a reference to an array, returns the resolved reference.
+      # Otherwise, makes sure :Contents is an array.
+      def ensure_contents_array
+        contents = dictionary.data[:Contents]
+        if contents.is_a?(PDF::Core::Reference) && contents.data.is_a?(Array)
+          return contents.data
+        end
+        # Ensure contents is an array.
+        dictionary.data[:Contents] = Array(contents)
+      end
+
       # As per the PDF spec, each page can have multiple content streams. This
       # will add a fresh, empty content stream this the page, mainly for use in
       # loading template files.
@@ -29,11 +40,9 @@ module PDF
       def new_content_stream
         return if in_stamp_stream?
 
-        unless dictionary.data[:Contents].is_a?(Array)
-          dictionary.data[:Contents] = [content]
-        end
         @content = document.ref({})
-        dictionary.data[:Contents] << document.state.store[@content]
+        contents = ensure_contents_array
+        contents << document.state.store[@content]
         document.open_graphics_state
       end
 


### PR DESCRIPTION
I ran into an issue with a PDF, where prawn-templates would cause the original PDF contents to disappear after adding it's own content stream.

I figured out the reason for this - `:Contents` was a reference that pointed to an array of references, which is a case that `prawn-templates` didn't appear to handle. I've annotated a screenshot from the [pdfwalker](https://github.com/gdelugre/pdfwalker) tool:

<img width="481" alt="screen shot 2017-10-18 at 8 43 00 pm" src="https://user-images.githubusercontent.com/139536/31724661-8b99fab4-b44c-11e7-92f4-f2d510adee4a.png">

This PR just adds support for this case, which fixes the issue.


