### PR TITLE
Fix malformed PDFs when :Contents is nil for a blank page

### DIFF
--- a/lib/pdf/core/page.rb
+++ b/lib/pdf/core/page.rb
@@ -69,7 +69,12 @@ module PDF
           dictionary.data[:Parent] = document.state.store.pages
         end
 
-        unless dictionary.data[:Contents].is_a?(Array) # content only on leafs
+        if !dictionary.data[:Contents]
+          # :Contents can sometimes be nil for blank pages.
+          # (This is technically a malformed PDF, but we can fix it here.)
+          @content = document.ref({})
+        elsif !dictionary.data[:Contents].is_a?(Array)
+          # content only on leafs
           @content = dictionary.data[:Contents].identifier
         end
 


### PR DESCRIPTION
This fixes a crash that I experienced when a malformed PDF had a blank page.

When I didn't fix the underlying issue by setting `document.ref({})`, this also caused a crash in other PDF tools (iText, PDFTK, etc.)