### PR TITLE
Fix typo in description

### DIFF
--- a/prawn-templates.gemspec
+++ b/prawn-templates.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rubocop', '~> 0.47')
   spec.add_development_dependency('rubocop-rspec', '~> 1.10')
   spec.homepage = 'https://github.com/prawnpdf/prawn-templates'
-  spec.description = 'A extention to prawn that allows to include other pdfs '\
+  spec.description = 'A extension to prawn that allows to include other pdfs '\
     'either as background to write upon or to combine several pdf documents '\
     'into one.'
 end


### PR DESCRIPTION
extention -> extension

Found by rpmlint during openSUSE packaging

RPMLINT report:

ruby2.6-rubygem-prawn-templates.x86_64: W: spelling-error %description -l C extention -> extension
ruby2.7-rubygem-prawn-templates.x86_64: W: spelling-error %description -l C extention -> extension
The value of this tag appears to be misspelled. Please double-check.

Signed-off-by: Petr Vorel <pvorel@suse.cz>